### PR TITLE
Remove pygeos as required dependency

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: BSD-3-Clause
 
 Summary: Parallel GeoPandas with Dask
 
+Development: https://github.com/geopandas/dask-geopandas/
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ requirements:
     - dask-core >=2021.06.0
     - distributed >=2021.06.0
     - packaging
-  run_constrained:
-    - shapely >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,17 +22,11 @@ requirements:
     - python >=3.7
     - geopandas-base >=0.10
     - dask-core >=2021.06.0
-    - distributed >=2021.06.0
     - packaging
 
 test:
   imports:
     - dask_geopandas
-  commands:
-    - pip check
-  requires:
-    - pip
-    - fiona
 
 about:
   home: https://github.com/geopandas/dask-geopandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python >=3.7
     - geopandas-base >=0.10
     - dask-core >=2021.06.0
+    - distributed >=2021.06.0
     - packaging
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - python >=3.7
     - geopandas-base >=0.10
     - dask-core >=2021.06.0
-    - distributed >=2021.06.0
     - packaging
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python >=3.7
     - geopandas-base >=0.10
     - dask-core >=2021.06.0
+    - distributed >=2021.06.0
     - packaging
 
 test:
@@ -31,6 +32,7 @@ test:
     - pip check
   requires:
     - pip
+    - fiona
 
 about:
   home: https://github.com/geopandas/dask-geopandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - dask-core >=2021.06.0
     - distributed >=2021.06.0
     - packaging
+  run_constrained:
+    - shapely >=2.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
+{% set name = "dask-geopandas" %}
 {% set version = "0.3.1" %}
 
 package:
-  name: dask-geopandas
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/geopandas/dask-geopandas/releases/download/v{{ version }}/dask-geopandas-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dask-geopandas-{{ version }}.tar.gz
   sha256: 032012d1dfd4d47b0009c3f89995fe5ee434edbaac78cac398637ceade9b26c3
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,18 +22,22 @@ requirements:
     - python >=3.7
     - geopandas-base >=0.10
     - dask-core >=2021.06.0
-    - pygeos
     - packaging
 
 test:
   imports:
     - dask_geopandas
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/geopandas/dask-geopandas
+  summary: Parallel GeoPandas with Dask
+  dev_url: https://github.com/geopandas/dask-geopandas/
   license: BSD-3-Clause
   license_file: LICENSE
-  summary: Parallel GeoPandas with Dask
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Xref https://github.com/geopandas/dask-geopandas/pull/232, removed in dask-geopandas 0.3.0.

Also needed to add ~`distributed` to runtime requirements, and~ `fiona` to test.requires to make `pip check` work.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Based on changes from https://github.com/conda-forge/dask-geopandas-feedstock/pull/13, but without the inspect-grayskull bot addition.

Closes #12.